### PR TITLE
Update FastAPI sample to use async DefaultAzureCredential

### DIFF
--- a/samples/middle-tier/python-fastapi/README.md
+++ b/samples/middle-tier/python-fastapi/README.md
@@ -11,7 +11,7 @@ The service establishes a WebSocket server that communicates with clients using 
 - **Simplified Protocol**: Uses a custom, lightweight communication protocol.
 - **Backend Support**: Works with both Azure OpenAI and OpenAI Realtime APIs.
 - **Extendable**: Easily extend the protocol to cover additional functionalities.
-- **Secure Authentication**: For Azure, utilizes token credentials through `DefaultAzureCredential`.
+- **Secure Authentication**: For Azure, uses async token credentials via `DefaultAzureCredential` from `azure.identity.aio`.
 - **Async Implementation**: Leverages FastAPI's async capabilities for efficient WebSocket handling.
 - **Type Safety**: Utilizes Python type hints throughout the codebase.
 
@@ -29,7 +29,7 @@ Set the following environment variables in a `.env` file at the root of the proj
 - `AZURE_OPENAI_ENDPOINT`: Your Azure OpenAI endpoint URL.
 - `AZURE_OPENAI_DEPLOYMENT`: The name of your Azure OpenAI deployment.
 
-Authentication is handled via `DefaultAzureCredential`, supporting environment-based credentials, managed identities, or Azure CLI authentication.
+Authentication is handled via `DefaultAzureCredential` from `azure.identity.aio`, requiring async credentials. It supports environment-based credentials, managed identities, or Azure CLI authentication.
 
 ### Using OpenAI Realtime API Backend
 
@@ -49,6 +49,8 @@ Authentication is handled via `DefaultAzureCredential`, supporting environment-b
     ```bash
     poetry install
     ```
+
+    This installs `azure-identity`, which contains the async `DefaultAzureCredential` used by the sample. If you run the code outside Poetry, ensure the package is installed with `pip install azure-identity`.
 
 3. **Start the Server**
 
@@ -113,6 +115,6 @@ class ControlMessage(TypedDict):
 ## Notes
 
 - Ensure that the required environment variables are set correctly for your chosen backend.
-- For Azure backend, authentication relies on DefaultAzureCredential, so configure your environment for token-based authentication.
+- For Azure backend, authentication relies on the async `DefaultAzureCredential` from `azure.identity.aio`, so configure your environment for token-based authentication.
 - Logging is configured using Loguru and can be adjusted through its configuration.
 - The server implements CORS middleware with permissive settings for development. Adjust these settings for production use.

--- a/samples/middle-tier/python-fastapi/rt-middle-tier/main.py
+++ b/samples/middle-tier/python-fastapi/rt-middle-tier/main.py
@@ -9,7 +9,7 @@ import asyncio
 from loguru import logger
 import os
 from dotenv import load_dotenv
-from azure.identity import DefaultAzureCredential
+from azure.identity.aio import DefaultAzureCredential
 from azure.core.credentials import AzureKeyCredential
 from rtclient import (
     InputAudioTranscription,
@@ -72,7 +72,12 @@ class RTSession:
 
         if backend == "azure" or backend is None:
             print("Using Azure OpenAI backend")
-            print("azure openai endpoint",os.getenv("AZURE_OPENAI_ENDPOINT")," deployemnt " ,os.getenv("AZURE_OPENAI_DEPLOYMENT"))
+            print(
+                "azure openai endpoint",
+                os.getenv("AZURE_OPENAI_ENDPOINT"),
+                " deployemnt ",
+                os.getenv("AZURE_OPENAI_DEPLOYMENT"),
+            )
             return RTClient(
                 url=os.getenv("AZURE_OPENAI_ENDPOINT"),
                 token_credential=DefaultAzureCredential(),


### PR DESCRIPTION
## Summary
- use `azure.identity.aio.DefaultAzureCredential` in FastAPI sample
- document async credential usage in the sample README
- note that `azure-identity` must be installed when running outside Poetry

## Testing
- `poetry run ruff check rt-middle-tier`
- `poetry run black --check rt-middle-tier`


------
https://chatgpt.com/codex/tasks/task_e_684fd117ccbc832b8618aa453c0bb223