### PR TITLE
Add Phi-3 langchain endpoint

### DIFF
--- a/samples/middle-tier/python-fastapi/README.md
+++ b/samples/middle-tier/python-fastapi/README.md
@@ -14,6 +14,7 @@ The service establishes a WebSocket server that communicates with clients using 
 - **Secure Authentication**: For Azure, uses async token credentials via `DefaultAzureCredential` from `azure.identity.aio`.
 - **Async Implementation**: Leverages FastAPI's async capabilities for efficient WebSocket handling.
 - **Type Safety**: Utilizes Python type hints throughout the codebase.
+- **Phi-3 Endpoint**: Includes a simple REST API for interacting with the Phi-3 model via LangChain.
 
 ## Environment Variables
 
@@ -35,6 +36,11 @@ Authentication is handled via `DefaultAzureCredential` from `azure.identity.aio`
 
 - `OPENAI_API_KEY`: Your OpenAI API key.
 - `OPENAI_MODEL`: The model to use (e.g., `gpt-3.5-turbo`).
+
+### Using Phi-3 via LangChain
+
+- `PHI3_ENDPOINT`: Hugging Face endpoint URL for the Phi-3 model.
+- `HF_API_TOKEN`: Hugging Face API token used to access the endpoint.
 
 ## Setup and Run
 
@@ -60,6 +66,7 @@ Authentication is handled via `DefaultAzureCredential` from `azure.identity.aio`
     ```
 
 The server listens on `http://localhost:<PORT>` and accepts WebSocket connections at the `/realtime` path.
+It also provides a `POST /phi3` endpoint which sends prompts to the Phi-3 model using LangChain and returns the generated text.
 
 ## Development Setup
 

--- a/samples/middle-tier/python-fastapi/README.md
+++ b/samples/middle-tier/python-fastapi/README.md
@@ -14,7 +14,7 @@ The service establishes a WebSocket server that communicates with clients using 
 - **Secure Authentication**: For Azure, uses async token credentials via `DefaultAzureCredential` from `azure.identity.aio`.
 - **Async Implementation**: Leverages FastAPI's async capabilities for efficient WebSocket handling.
 - **Type Safety**: Utilizes Python type hints throughout the codebase.
-- **Phi-3 Endpoint**: Includes a simple REST API for interacting with the Phi-3 model via LangChain.
+- **Phi-3 Endpoint**: Provides a REST API for interacting with a local Phi-3 model via Ollama and LangChain.
 
 ## Environment Variables
 
@@ -39,8 +39,8 @@ Authentication is handled via `DefaultAzureCredential` from `azure.identity.aio`
 
 ### Using Phi-3 via LangChain
 
-- `PHI3_ENDPOINT`: Hugging Face endpoint URL for the Phi-3 model.
-- `HF_API_TOKEN`: Hugging Face API token used to access the endpoint.
+- `OLLAMA_BASE_URL` (optional): Base URL for your Ollama server (default `http://localhost:11434`).
+- `PHI3_MODEL` (optional): Name of the model to load in Ollama (default `phi3`).
 
 ## Setup and Run
 
@@ -66,7 +66,7 @@ Authentication is handled via `DefaultAzureCredential` from `azure.identity.aio`
     ```
 
 The server listens on `http://localhost:<PORT>` and accepts WebSocket connections at the `/realtime` path.
-It also provides a `POST /phi3` endpoint which sends prompts to the Phi-3 model using LangChain and returns the generated text.
+It also provides a `POST /phi3` endpoint which sends prompts to a local Phi-3 model via Ollama and returns the generated text.
 
 ## Development Setup
 

--- a/samples/middle-tier/python-fastapi/pyproject.toml
+++ b/samples/middle-tier/python-fastapi/pyproject.toml
@@ -17,6 +17,8 @@ azure-identity = "^1.19.0"
 azure-core = "^1.32.0"
 websockets = "^14.1"
 rtclient = { url = "https://github.com/Azure-Samples/aoai-realtime-audio-sdk/releases/download/py%2Fv0.5.3/rtclient-0.5.3.tar.gz" }
+langchain-community = "^0.3.25"
+transformers = "^4.52.4"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.10.0"

--- a/samples/middle-tier/python-fastapi/pyproject.toml
+++ b/samples/middle-tier/python-fastapi/pyproject.toml
@@ -18,7 +18,6 @@ azure-core = "^1.32.0"
 websockets = "^14.1"
 rtclient = { url = "https://github.com/Azure-Samples/aoai-realtime-audio-sdk/releases/download/py%2Fv0.5.3/rtclient-0.5.3.tar.gz" }
 langchain-community = "^0.3.25"
-transformers = "^4.52.4"
 
 [tool.poetry.group.dev.dependencies]
 black = "^24.10.0"

--- a/samples/middle-tier/python-fastapi/rt-middle-tier/main.py
+++ b/samples/middle-tier/python-fastapi/rt-middle-tier/main.py
@@ -11,7 +11,7 @@ from loguru import logger
 import os
 from dotenv import load_dotenv
 from azure.identity.aio import DefaultAzureCredential
-from langchain_community.llms import HuggingFaceEndpoint
+from langchain_community.llms import Ollama
 from azure.core.credentials import AzureKeyCredential
 from rtclient import (
     InputAudioTranscription,
@@ -251,12 +251,9 @@ app.add_middleware(
 
 @app.post("/phi3")
 async def phi3_endpoint(req: Phi3Request):
-    hf_endpoint = os.getenv("PHI3_ENDPOINT")
-    hf_token = os.getenv("HF_API_TOKEN")
-    llm = HuggingFaceEndpoint(
-        endpoint_url=hf_endpoint,
-        huggingfacehub_api_token=hf_token,
-    )
+    base_url = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+    model = os.getenv("PHI3_MODEL", "phi3")
+    llm = Ollama(base_url=base_url, model=model)
     response = await llm.apredict(req.prompt)
     return {"response": response}
 

--- a/samples/middle-tier/python-fastapi/rt-middle-tier/main.py
+++ b/samples/middle-tier/python-fastapi/rt-middle-tier/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, WebSocket
+from pydantic import BaseModel
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.websockets import WebSocketState
 import uvicorn
@@ -10,6 +11,7 @@ from loguru import logger
 import os
 from dotenv import load_dotenv
 from azure.identity.aio import DefaultAzureCredential
+from langchain_community.llms import HuggingFaceEndpoint
 from azure.core.credentials import AzureKeyCredential
 from rtclient import (
     InputAudioTranscription,
@@ -46,6 +48,10 @@ class ControlMessage(TypedDict):
     action: str
     greeting: str | None = None
     id: str | None = None
+
+
+class Phi3Request(BaseModel):
+    prompt: str
 
 
 WSMessage = Union[TextDelta, Transcription, UserMessage, ControlMessage]
@@ -241,6 +247,18 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+@app.post("/phi3")
+async def phi3_endpoint(req: Phi3Request):
+    hf_endpoint = os.getenv("PHI3_ENDPOINT")
+    hf_token = os.getenv("HF_API_TOKEN")
+    llm = HuggingFaceEndpoint(
+        endpoint_url=hf_endpoint,
+        huggingfacehub_api_token=hf_token,
+    )
+    response = await llm.apredict(req.prompt)
+    return {"response": response}
 
 
 @app.websocket("/realtime")


### PR DESCRIPTION
## Summary
- add `langchain-community` and `transformers` dependencies
- expose `/phi3` REST API that calls a Hugging Face endpoint using LangChain
- document the new Phi-3 endpoint and environment variables

## Testing
- `poetry run black rt-middle-tier`
- `poetry run ruff check rt-middle-tier`
- `poetry run pytest -q` *(fails: Using pytest.skip outside of a test)*

------
https://chatgpt.com/codex/tasks/task_e_684fd08be3c4832b92fffd512cf58e09