### PR TITLE
Add dark mode toggle to generic frontend

### DIFF
--- a/samples/middle-tier/generic-frontend/README.md
+++ b/samples/middle-tier/generic-frontend/README.md
@@ -10,6 +10,7 @@ A Next.js-based chat application demonstrating the usage of RTClient for real-ti
 - ☁️ Support for both OpenAI and Azure OpenAI
 - 🛠️ Configurable conversation settings
 - 🔧 Tool integration support (coming soon)
+- 🌙 Light and dark theme toggle
 
 ## Prerequisites
 
@@ -41,6 +42,7 @@ yarn dev
 ```
 
 4. Open [http://localhost:3000](http://localhost:3000) in your browser.
+   Use the moon icon in the sidebar to switch between light and dark themes.
 
 ## Usage
 

--- a/samples/middle-tier/generic-frontend/package.json
+++ b/samples/middle-tier/generic-frontend/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@radix-ui/react-accordion": "^1.2.1",
     "@radix-ui/react-icons": "^1.3.2",
+    "@radix-ui/react-radio-group": "^1.3.7",
     "@radix-ui/react-select": "^2.1.2",
     "@radix-ui/react-slider": "^1.2.1",
     "@radix-ui/react-slot": "^1.1.0",

--- a/samples/middle-tier/generic-frontend/src/app/chat-interface.tsx
+++ b/samples/middle-tier/generic-frontend/src/app/chat-interface.tsx
@@ -1,9 +1,10 @@
 "use client";
 
 import React, { useState, useRef, useEffect } from "react";
-import { Send, Mic, MicOff, Power } from "lucide-react";
+import { Send, Mic, MicOff, Power, Upload } from "lucide-react";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
+import * as RadioGroup from "@radix-ui/react-radio-group";
 import {
   Accordion,
   AccordionContent,
@@ -85,6 +86,8 @@ const ChatInterface = () => {
   const [isConnected, setIsConnected] = useState(false);
   const [isConnecting, setIsConnecting] = useState(false);
   const [validEndpoint, setValidEndpoint] = useState(true);
+  const [selectedModel, setSelectedModel] = useState("azure");
+
   const webSocketClient = useRef<WebSocketClient | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const messageMap = useRef(new Map<string, Message>());
@@ -102,11 +105,40 @@ const ChatInterface = () => {
     scrollToBottom();
   }, [messages]);
 
+  const handleFileUpload = async (file: File) => {
+    if (selectedModel !== "phi3") return;
+    const formData = new FormData();
+    formData.append("file", file);
+
+    try {
+      const response = await fetch("http://localhost:8080/upload", {
+        method: "POST",
+        body: formData,
+      });
+      const data = await response.json();
+      const uploadResponse: Message = {
+        id: `upload-${Date.now()}`,
+        type: "assistant",
+        content: data.message || "File uploaded and processed successfully.",
+      };
+      setMessages((prev) => [...prev, uploadResponse]);
+    } catch (error) {
+      console.error("File upload failed:", error);
+    }
+  };
+
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (file) {
+      handleFileUpload(file);
+    }
+  };
+
   const handleWSMessage = async (message: WSMessage) => {
     switch (message.type) {
       case "transcription":
         if (message.id) {
-          currentUserMessage.current!.content = message.text!
+          currentUserMessage.current!.content = message.text!;
           setMessages(Array.from(messageMap.current.values()));
         }
         break;
@@ -160,6 +192,28 @@ const ChatInterface = () => {
   };
 
   const handleConnect = async () => {
+    if (selectedModel === "phi3") {
+      // Send prompt to /phi3 endpoint
+      // try {
+      //   const response = await fetch("http://localhost:8080/phi3", {
+      //     method: "POST",
+      //     headers: { "Content-Type": "application/json" },
+      //     body: JSON.stringify({ prompt: currentMessage }),
+      //   });
+      //   const data = await response.json();
+      //   const newMessage: Message = {
+      //     id: `assistant-${Date.now()}`,
+      //     type: "assistant",
+      //     content: data.response || "Response received.",
+      //   };
+      //   setMessages((prev) => [...prev, newMessage]);
+      // } catch (error) {
+      //   console.error("Error calling Phi-3 API:", error);
+      // }
+      setIsConnected(true);
+      return; // Skip WebSocket connection if Phi-3
+    }
+
     if (isConnected) {
       await disconnect();
     } else {
@@ -169,10 +223,10 @@ const ChatInterface = () => {
         type: "status",
         content: "Connecting...",
       };
-      messageMap.current.clear(); // Clear messages on new connection
+      messageMap.current.clear();
       messageMap.current.set(statusMessageId, currentConnectingMessage.current);
       setMessages(Array.from(messageMap.current.values()));
-  setIsConnecting(true);
+      setIsConnecting(true);
       try {
         webSocketClient.current = new WebSocketClient(new URL(endpoint));
         setIsConnected(true);
@@ -199,12 +253,8 @@ const ChatInterface = () => {
   };
 
   const sendMessage = async () => {
-    if (currentMessage.trim() && webSocketClient.current) {
+    if (currentMessage.trim()) {
       const messageId = `user-${Date.now()}`;
-      const message = {
-        type: "user_message",
-        text: currentMessage,
-      };
       const newMessage: Message = {
         id: messageId,
         type: "user",
@@ -213,10 +263,32 @@ const ChatInterface = () => {
       messageMap.current.set(messageId, newMessage);
       setMessages(Array.from(messageMap.current.values()));
       setCurrentMessage("");
-      await webSocketClient.current.send({
-        type: "text",
-        data: JSON.stringify(message),
-      });
+
+      if (selectedModel === "phi3") {
+        try {
+          const response = await fetch("http://localhost:8080/phi3", {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ prompt: newMessage.content }),
+          });
+          const data = await response.json();
+          const assistantMsgId = `assistant-${Date.now()}`;
+          const assistantMsg: Message = {
+            id: assistantMsgId,
+            type: "assistant",
+            content: data.response || "Response received.",
+          };
+            messageMap.current.set(assistantMsgId, assistantMsg);
+            setMessages(Array.from(messageMap.current.values()));
+        } catch (err) {
+          console.error("Error sending to Phi-3:", err);
+        }
+      } else if (webSocketClient.current) {
+        await webSocketClient.current.send({
+          type: "text",
+          data: JSON.stringify({ type: "user_message", text: newMessage.content }),
+        });
+      }
     }
   };
 
@@ -256,7 +328,7 @@ const ChatInterface = () => {
           <Accordion type="single" className="space-y-4" value="connection">
             <AccordionItem value="connection">
               <AccordionTrigger className="text-lg font-semibold">
-                Middle Tier Endpoint
+                <span  className="font-montserrat blue">MEGANEXUS</span>
               </AccordionTrigger>
               <AccordionContent className="space-y-4">
                 <Input
@@ -265,6 +337,40 @@ const ChatInterface = () => {
                   onChange={(e) => validateEndpoint(e.target.value)}
                   disabled={isConnected}
                 />
+                <RadioGroup.Root
+                  className="space-y-2"
+                  value={selectedModel}
+                  onValueChange={(val) => setSelectedModel(val)}
+                >
+                  <div className="flex items-center gap-2">
+                    <RadioGroup.Item
+                      className="bg-white w-5 h-5 rounded-full border border-gray-400 data-[state=checked]:bg-blue-600"
+                      value="azure"
+                      id="azure"
+                    >
+                      <RadioGroup.Indicator className="flex items-center justify-center w-full h-full">
+                        <div className="w-2 h-2 bg-white rounded-full" />
+                      </RadioGroup.Indicator>
+                    </RadioGroup.Item>
+                    <label htmlFor="azure" className="text-sm">
+                      Azure OpenAI
+                    </label>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <RadioGroup.Item
+                      className="bg-white w-5 h-5 rounded-full border border-gray-400 data-[state=checked]:bg-green-600"
+                      value="phi3"
+                      id="phi3"
+                    >
+                      <RadioGroup.Indicator className="flex items-center justify-center w-full h-full">
+                        <div className="w-2 h-2 bg-white rounded-full" />
+                      </RadioGroup.Indicator>
+                    </RadioGroup.Item>
+                    <label htmlFor="phi3" className="text-sm">
+                      Phi-3
+                    </label>
+                  </div>
+                </RadioGroup.Root>
               </AccordionContent>
             </AccordionItem>
           </Accordion>
@@ -304,29 +410,39 @@ const ChatInterface = () => {
         </div>
 
         <div className="p-4 border-t">
-          <div className="flex gap-2">
+          <div className="flex gap-2 items-center">
             <Input
               value={currentMessage}
               onChange={(e) => setCurrentMessage(e.target.value)}
               placeholder="Type your message..."
               onKeyUp={(e) => e.key === "Enter" && sendMessage()}
-              disabled={!isConnected}
+              disabled={!isConnected || selectedModel !== "phi3"}
             />
             <Button
               variant="outline"
               onClick={toggleRecording}
               className={isRecording ? "bg-destructive text-destructive-foreground" : ""}
-              disabled={!isConnected}
+              disabled={!isConnected || selectedModel !== "phi3"}
             >
-              {isRecording ? (
-                <Mic className="w-4 h-4" />
-              ) : (
-                <MicOff className="w-4 h-4" />
-              ) }
+              {isRecording ? <Mic className="w-4 h-4" /> : <MicOff className="w-4 h-4" />}
             </Button>
-            <Button onClick={sendMessage} disabled={!isConnected}>
+            <Button
+              onClick={sendMessage}
+              disabled={!isConnected || selectedModel !== "phi3"}
+            >
               <Send className="w-4 h-4" />
             </Button>
+            <label htmlFor="file-upload" className="cursor-pointer">
+              <Upload className="w-5 h-5" />
+            </label>
+            <input
+              id="file-upload" 
+              type="file"
+              accept=".pdf,.doc,.docx,.txt"
+              onChange={handleFileChange}
+              className="hidden"
+              disabled={!isConnected || selectedModel !== "phi3"}
+            />
           </div>
         </div>
       </div>

--- a/samples/middle-tier/generic-frontend/src/app/chat-interface.tsx
+++ b/samples/middle-tier/generic-frontend/src/app/chat-interface.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/accordion";
 import { Player, Recorder } from "@/lib/audio";
 import { WebSocketClient } from "@/lib/client";
+import ThemeToggle from "@/components/theme-toggle";
 
 interface Message {
   id: string;
@@ -249,8 +250,8 @@ const ChatInterface = () => {
   };
 
   return (
-    <div className="flex h-screen">
-      <div className="w-80 bg-gray-50 p-4 flex flex-col border-r">
+    <div className="flex h-screen bg-background text-foreground">
+      <div className="w-80 bg-background p-4 flex flex-col border-r border-border">
         <div className="flex-1 overflow-y-auto">
           <Accordion type="single" className="space-y-4" value="connection">
             <AccordionItem value="connection">
@@ -268,15 +269,17 @@ const ChatInterface = () => {
             </AccordionItem>
           </Accordion>
         </div>
-        <Button
-          className="mt-4"
-          variant={isConnected ? "destructive" : "default"}
-          onClick={handleConnect}
-          disabled={isConnecting || !validEndpoint}
-        >
-          <Power className="w-4 h-4 mr-2" />
-          {isConnecting ? "Connecting..." : isConnected ? "Disconnect" : "Connect"}
-        </Button>
+        <div className="mt-4 flex items-center gap-2">
+          <Button
+            variant={isConnected ? "destructive" : "default"}
+            onClick={handleConnect}
+            disabled={isConnecting || !validEndpoint}
+          >
+            <Power className="w-4 h-4 mr-2" />
+            {isConnecting ? "Connecting..." : isConnected ? "Disconnect" : "Connect"}
+          </Button>
+          <ThemeToggle />
+        </div>
       </div>
 
       <div className="flex-1 flex flex-col">
@@ -287,10 +290,10 @@ const ChatInterface = () => {
                 key={message.id}
                 className={`p-3 rounded-lg ${
                   message.type === "user"
-                    ? "bg-blue-100 ml-auto max-w-[80%]"
+                    ? "bg-primary text-primary-foreground ml-auto max-w-[80%]"
                     : message.type === "status"
-                    ? "bg-gray-50 mx-auto max-w-[80%] text-center"
-                    : "bg-gray-100 mr-auto max-w-[80%]"
+                    ? "bg-muted text-muted-foreground mx-auto max-w-[80%] text-center"
+                    : "bg-secondary text-secondary-foreground mr-auto max-w-[80%]"
                 }`}
               >
                 {message.content}
@@ -312,7 +315,7 @@ const ChatInterface = () => {
             <Button
               variant="outline"
               onClick={toggleRecording}
-              className={isRecording ? "bg-red-100" : ""}
+              className={isRecording ? "bg-destructive text-destructive-foreground" : ""}
               disabled={!isConnected}
             >
               {isRecording ? (

--- a/samples/middle-tier/generic-frontend/src/app/globals.css
+++ b/samples/middle-tier/generic-frontend/src/app/globals.css
@@ -6,6 +6,15 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
+.font-montserrat {
+  font-family: "Montserrat", sans-serif;
+}
+.blue {
+  color: #007bff;
+}
+.orange {
+  color: #F08030;
+} 
 @layer base {
   :root {
     --background: 0 0% 100%;

--- a/samples/middle-tier/generic-frontend/src/app/layout.tsx
+++ b/samples/middle-tier/generic-frontend/src/app/layout.tsx
@@ -24,12 +24,17 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang="en" suppressHydrationWarning>
       <head>
         <link rel="icon" href="/icon.svg" />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `(() => { try { const t = localStorage.getItem('theme'); const d = t ? t === 'dark' : window.matchMedia('(prefers-color-scheme: dark)').matches; if (d) document.documentElement.classList.add('dark'); } catch(e) {} })();`,
+          }}
+        />
       </head>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-background text-foreground`}
       >
         {children}
       </body>

--- a/samples/middle-tier/generic-frontend/src/components/theme-toggle.tsx
+++ b/samples/middle-tier/generic-frontend/src/components/theme-toggle.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Moon, Sun } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Button } from "@/components/ui/button";
+
+export default function ThemeToggle() {
+  const [theme, setTheme] = useState<"light" | "dark">("light");
+
+  useEffect(() => {
+    const stored = localStorage.getItem("theme");
+    const initial = stored
+      ? (stored as "light" | "dark")
+      : window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+    setTheme(initial);
+    document.documentElement.classList.toggle("dark", initial === "dark");
+  }, []);
+
+  const toggleTheme = () => {
+    const newTheme = theme === "dark" ? "light" : "dark";
+    setTheme(newTheme);
+    localStorage.setItem("theme", newTheme);
+    document.documentElement.classList.toggle("dark", newTheme === "dark");
+  };
+
+  return (
+    <Button
+      variant="ghost"
+      size="icon"
+      onClick={toggleTheme}
+      aria-label="Toggle theme"
+    >
+      {theme === "dark" ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+    </Button>
+  );
+}


### PR DESCRIPTION
## Summary
- add a theme toggle button component
- enable dark mode in layout and chat interface
- use theme colors for message styling
- document dark mode usage

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685512d2ea24832ba0364583af63ca77