### PR TITLE
Update dark mode colors

### DIFF
--- a/samples/middle-tier/generic-frontend/src/app/globals.css
+++ b/samples/middle-tier/generic-frontend/src/app/globals.css
@@ -51,7 +51,8 @@ body {
     --card-foreground: 0 0% 98%;
     --popover: 238 40% 13%;
     --popover-foreground: 0 0% 98%;
-    --primary: 0 0% 98%;
+    /* Brand orange for primary backgrounds */
+    --primary: 25 86% 56%;
     --primary-foreground: 0 0% 9%;
     --secondary: 0 0% 14.9%;
     --secondary-foreground: 0 0% 98%;
@@ -61,8 +62,9 @@ body {
     --accent-foreground: 0 0% 98%;
     --destructive: 0 62.8% 30.6%;
     --destructive-foreground: 0 0% 98%;
-    --border: 0 0% 14.9%;
-    --input: 0 0% 14.9%;
+    /* White borders for higher contrast */
+    --border: 0 0% 100%;
+    --input: 0 0% 100%;
     --ring: 0 0% 83.1%;
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;


### PR DESCRIPTION
## Summary
- tweak dark mode in the generic frontend sample
  - primary background colour now brand orange
  - white borders for greater contrast

## Testing
- `npm run lint` in `samples/middle-tier/generic-frontend`

------
https://chatgpt.com/codex/tasks/task_e_685520e777a8832bae8ef888ec3a76a1