### PR TITLE
Refactor FastAPI main script

### DIFF
--- a/samples/middle-tier/python-fastapi/rt-middle-tier/document_store.py
+++ b/samples/middle-tier/python-fastapi/rt-middle-tier/document_store.py
@@ -1,0 +1,105 @@
+import os
+from typing import List
+from loguru import logger
+from sentence_transformers import SentenceTransformer, util
+import weaviate
+from weaviate.classes.data import DataObject
+from weaviate.classes.config import Configure, Property, DataType
+from weaviate.classes.init import Auth
+
+
+embedder = SentenceTransformer("all-MiniLM-L6-v2")
+
+WEAVIATE_HOST = os.getenv("WEAVIATE_HOST")
+WEAVIATE_PORT = int(os.getenv("WEAVIATE_PORT", "0"))
+WEAVIATE_SECURE = bool(os.getenv("WEAVIATE_SECURE"))
+WEAVIATE_GRPC_HOST = os.getenv("WEAVIATE_GRPC_HOST")
+WEAVIATE_GRPC_PORT = int(os.getenv("WEAVIATE_GRPC_PORT", "50051"))
+WEAVIATE_GRPC_SECURE = bool(os.getenv("WEAVIATE_GRPC_SECURE"))
+WEAVIATE_AUTH_CREDENTIALS = os.getenv("WEAVIATE_AUTH_CREDENTIALS")
+
+weaviate_client = None
+
+
+def get_weaviate_client():
+    """Initialize and return a Weaviate client instance."""
+    global weaviate_client
+    if weaviate_client is None:
+        try:
+            logger.info(
+                "Connecting to Weaviate at %s:%s secure=%s",
+                WEAVIATE_HOST,
+                WEAVIATE_PORT,
+                WEAVIATE_SECURE,
+            )
+            weaviate_client = weaviate.connect_to_custom(
+                http_host=WEAVIATE_HOST,
+                http_port=WEAVIATE_PORT,
+                http_secure=WEAVIATE_SECURE,
+                grpc_host=WEAVIATE_GRPC_HOST,
+                grpc_port=WEAVIATE_GRPC_PORT,
+                grpc_secure=WEAVIATE_GRPC_SECURE,
+                auth_credentials=Auth.api_key(WEAVIATE_AUTH_CREDENTIALS),
+            )
+        except Exception as exc:
+            logger.warning(f"Could not connect to Weaviate: {exc}")
+    return weaviate_client
+
+
+class DocumentStore:
+    """Manage document chunks and semantic search."""
+
+    def __init__(self) -> None:
+        self.chunks: List[str] = []
+        self.embeddings = []
+        self.client = get_weaviate_client()
+
+    def update(self, text: str) -> None:
+        """Split, embed, and store chunks from a document."""
+        self.chunks = [text[i : i + 500] for i in range(0, len(text), 500)]
+        self.embeddings = embedder.encode(self.chunks)
+
+        if self.client is None:
+            logger.warning("Weaviate client not initialized, skipping storage")
+            return
+
+        try:
+            try:
+                self.client.collections.delete("DocumentChunk")
+            except Exception:
+                logger.debug("No existing DocumentChunk collection to delete")
+
+            self.client.collections.create(
+                name="DocumentChunk",
+                description="Document chunks for semantic search",
+                properties=[Property(name="text", data_type=DataType.TEXT)],
+                vectorizer_config=Configure.Vectorizer.none(),
+            )
+            collection = self.client.collections.get("DocumentChunk")
+            objects = [
+                DataObject(properties={"text": chunk}, vector=vector.tolist())
+                for chunk, vector in zip(self.chunks, self.embeddings)
+            ]
+            collection.data.insert_many(objects)
+            logger.info("Stored document chunks in Weaviate")
+        except Exception as exc:
+            logger.warning(f"Failed to store in Weaviate: {exc}")
+
+    def search(self, query: str) -> str:
+        """Retrieve relevant context for the query."""
+        if self.client is not None and self.client.collections.exists("DocumentChunk"):
+            collection = self.client.collections.get("DocumentChunk")
+            query_embedding = embedder.encode(query)
+            try:
+                results = collection.query.near_vector(query_embedding.tolist(), limit=3)
+                return "\n---\n".join(obj.properties["text"] for obj in results.objects)
+            except Exception as exc:
+                logger.warning(f"Weaviate query failed: {exc}")
+
+        if self.chunks and self.embeddings:
+            query_embedding = embedder.encode(query, convert_to_tensor=True)
+            top_results = util.semantic_search(query_embedding, self.embeddings, top_k=3)
+            return "\n---\n".join(
+                self.chunks[match["corpus_id"]] for match in top_results[0]
+            )
+        return ""

--- a/samples/middle-tier/python-fastapi/rt-middle-tier/document_store.py
+++ b/samples/middle-tier/python-fastapi/rt-middle-tier/document_store.py
@@ -96,7 +96,7 @@ class DocumentStore:
             except Exception as exc:
                 logger.warning(f"Weaviate query failed: {exc}")
 
-        if self.chunks and self.embeddings:
+        if self.chunks and len(self.embeddings) > 0:
             query_embedding = embedder.encode(query, convert_to_tensor=True)
             top_results = util.semantic_search(query_embedding, self.embeddings, top_k=3)
             return "\n---\n".join(

--- a/samples/middle-tier/python-fastapi/rt-middle-tier/llm.py
+++ b/samples/middle-tier/python-fastapi/rt-middle-tier/llm.py
@@ -1,0 +1,33 @@
+import os
+from abc import ABC, abstractmethod
+from langchain_community.llms.ollama import Ollama
+
+
+class BaseLLMModel(ABC):
+    """Abstract base class for language models."""
+
+    @abstractmethod
+    async def generate(self, prompt: str) -> str:
+        """Generate a response for the given prompt."""
+        raise NotImplementedError
+
+
+class OllamaModel(BaseLLMModel):
+    def __init__(self, base_url: str, model: str) -> None:
+        self._client = Ollama(base_url=base_url, model=model)
+
+    async def generate(self, prompt: str) -> str:
+        return await self._client.apredict(prompt)
+
+
+class ModelFactory:
+    """Factory to create model instances."""
+
+    @staticmethod
+    def create(model_name: str | None = None) -> BaseLLMModel:
+        model_name = model_name or os.getenv("LLM_PROVIDER", "ollama")
+        if model_name == "ollama":
+            base_url = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+            model = os.getenv("PHI3_MODEL", "phi3.5:3.8b")
+            return OllamaModel(base_url=base_url, model=model)
+        raise ValueError(f"Unknown model provider: {model_name}")

--- a/samples/middle-tier/python-fastapi/rt-middle-tier/main.py
+++ b/samples/middle-tier/python-fastapi/rt-middle-tier/main.py
@@ -18,9 +18,9 @@ from pypdf import PdfReader
 import docx2txt
 from dotenv import load_dotenv
 
-from document_store import DocumentStore
-from llm import ModelFactory
-from rt_session import RTSession
+from .document_store import DocumentStore
+from .llm import ModelFactory
+from .rt_session import RTSession
 
 
 load_dotenv()

--- a/samples/middle-tier/python-fastapi/rt-middle-tier/main.py
+++ b/samples/middle-tier/python-fastapi/rt-middle-tier/main.py
@@ -1,194 +1,34 @@
 from fastapi import FastAPI, WebSocket, UploadFile, File
-from pydantic import BaseModel
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.websockets import WebSocketState
-import uvicorn
-import uuid
-import json
-from typing import Union, Literal, TypedDict, Dict, List, Tuple
-import asyncio
+from pydantic import BaseModel
 from loguru import logger
+import uvicorn
 import os
-from dotenv import load_dotenv
-from azure.identity.aio import DefaultAzureCredential
-from langchain_community.llms.ollama import Ollama
-from azure.core.credentials import AzureKeyCredential
-from rtclient import (
-    InputAudioTranscription,
-    RTClient,
-    ServerVAD,
-    RTInputAudioItem,
-    RTResponse,
-    RTAudioContent,
-)
-from sentence_transformers import SentenceTransformer, util
 import io
-from pypdf import PdfReader
-import docx2txt
+import tempfile
+import subprocess
+import json
+import uuid
+from typing import Dict, List, Tuple, Union, Literal, TypedDict
 import pandas as pd
 from bs4 import BeautifulSoup
 import markdown
-import tempfile
-import subprocess
-import weaviate
-from weaviate.classes.data import DataObject
-from weaviate.classes.init import Auth
-from weaviate.classes.config import Configure, Property, DataType
-from abc import ABC, abstractmethod
+from pypdf import PdfReader
+import docx2txt
+from dotenv import load_dotenv
 
+from document_store import DocumentStore
+from llm import ModelFactory
+from rt_session import RTSession
 
 
 load_dotenv()
 
-embedder = SentenceTransformer("all-MiniLM-L6-v2")
-
-class BaseLLMModel(ABC):
-    """Abstract base class for language models."""
-
-    @abstractmethod
-    async def generate(self, prompt: str) -> str:
-        pass
-
-
-class OllamaModel(BaseLLMModel):
-    def __init__(self, base_url: str, model: str) -> None:
-        self._client = Ollama(base_url=base_url, model=model)
-
-    async def generate(self, prompt: str) -> str:
-        return await self._client.apredict(prompt)
-
-
-class ModelFactory:
-    """Factory to create model instances."""
-
-    @staticmethod
-    def create(model_name: str | None = None) -> BaseLLMModel:
-        model_name = model_name or os.getenv("LLM_PROVIDER", "ollama")
-        if model_name == "ollama":
-            base_url = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
-            model = os.getenv("PHI3_MODEL", "phi3.5:3.8b")
-            return OllamaModel(base_url=base_url, model=model)
-        raise ValueError(f"Unknown model provider: {model_name}")
-
-
-class DocumentStore:
-    """Manage document chunks and semantic search."""
-
-    def __init__(self):
-        self.chunks: List[str] = []
-        self.embeddings = []
-        self.client = get_weaviate_client()
-
-    def update(self, text: str) -> None:
-        self.chunks = [text[i : i + 500] for i in range(0, len(text), 500)]
-        self.embeddings = embedder.encode(self.chunks)
-        if self.client is None:
-            logger.warning("Weaviate client is not initialized, skipping storage")
-            return
-        try:
-            try:
-                self.client.collections.delete("DocumentChunk")
-            except Exception:
-                logger.debug("No existing DocumentChunk class to delete")
-            self.client.collections.create(
-                name="DocumentChunk",
-                description="A collection of documents split into chunks for semantic search",
-                properties=[Property(name="text", data_type=DataType.TEXT)],
-                vectorizer_config=Configure.Vectorizer.none(),
-            )
-            collection = self.client.collections.get("DocumentChunk")
-            objects = [
-                DataObject(properties={"text": chunk}, vector=vector.tolist())
-                for chunk, vector in zip(self.chunks, self.embeddings)
-            ]
-            collection.data.insert_many(objects)
-            logger.info("Stored document chunks in Weaviate")
-        except Exception as exc:
-            logger.warning(f"Failed to store in Weaviate: {exc}")
-
-    def search(self, query: str) -> str:
-        if self.client is not None and self.client.collections.exists("DocumentChunk"):
-            collection = self.client.collections.get("DocumentChunk")
-            query_embedding = embedder.encode(query)
-            try:
-                results = collection.query.near_vector(query_embedding.tolist(), limit=3)
-                return "\n---\n".join(obj.properties["text"] for obj in results.objects)
-            except Exception as exc:
-                logger.warning(f"Weaviate query failed: {exc}")
-        if self.chunks and self.embeddings:
-            query_embedding = embedder.encode(query, convert_to_tensor=True)
-            top_results = util.semantic_search(query_embedding, self.embeddings, top_k=3)
-            return "\n---\n".join(self.chunks[match["corpus_id"]] for match in top_results[0])
-        return ""
-
-
-# Simple in-memory storage for conversation history.
-# Maps a session id to a list of (question, answer) tuples.
+# Simple in-memory storage for conversation history
 mem0: Dict[str, List[Tuple[str, str]]] = {}
 
-WEAVIATE_GRPC_PORT = int(os.getenv("WEAVIATE_GRPC_PORT", "50051"))
-weaviate_client = None
-
-WEAVIATE_HOST = os.getenv("WEAVIATE_HOST")
-WEAVIATE_PORT = int(os.getenv("WEAVIATE_PORT"))
-WEAVIATE_SECURE = bool(os.getenv("WEAVIATE_SECURE"))  # False if empty
-WEAVIATE_GRPC_HOST = os.getenv("WEAVIATE_GRPC_HOST")
-WEAVIATE_GRPC_PORT = int(os.getenv("WEAVIATE_GRPC_PORT"))
-WEAVIATE_GRPC_SECURE = bool(os.getenv("WEAVIATE_GRPC_SECURE"))  # False if empty
-WEAVIATE_AUTH_CREDENTIALS = os.getenv("WEAVIATE_AUTH_CREDENTIALS")
-print(
-    f"Connecting to Weaviate at {WEAVIATE_HOST}:{WEAVIATE_PORT} with secure={WEAVIATE_SECURE}"
-)
-
-
-def get_weaviate_client():
-    global weaviate_client
-    if weaviate_client is None:
-
-        print(
-            f"Connecting to Weaviate at {WEAVIATE_HOST}:{WEAVIATE_PORT} with secure={WEAVIATE_SECURE}"
-        )
-
-        try:
-            weaviate_client = weaviate.connect_to_custom(
-                http_host=WEAVIATE_HOST,
-                http_port=WEAVIATE_PORT,
-                http_secure=WEAVIATE_SECURE,
-                grpc_host=WEAVIATE_GRPC_HOST,
-                grpc_port=WEAVIATE_GRPC_PORT,
-                grpc_secure=WEAVIATE_GRPC_SECURE,
-                auth_credentials=Auth.api_key(WEAVIATE_AUTH_CREDENTIALS),
-            )
-        except Exception as e:
-            logger.warning(f"Could not connect to Weaviate: {e}")
-    return weaviate_client
-
-
 document_store = DocumentStore()
-
-class TextDelta(TypedDict):
-    id: str
-    type: Literal["text_delta"]
-    delta: str
-
-
-class Transcription(TypedDict):
-    id: str
-    type: Literal["transcription"]
-    text: str
-
-
-class UserMessage(TypedDict):
-    id: str
-    type: Literal["user_message"]
-    text: str
-
-
-class ControlMessage(TypedDict):
-    type: Literal["control"]
-    action: str
-    greeting: str | None = None
-    id: str | None = None
 
 
 class Phi3Request(BaseModel):
@@ -196,191 +36,7 @@ class Phi3Request(BaseModel):
     session_id: str | None = None
 
 
-WSMessage = Union[TextDelta, Transcription, UserMessage, ControlMessage]
-
-
-class RTSession:
-    def __init__(self, websocket: WebSocket, backend: str | None):
-        self.session_id = str(uuid.uuid4())
-        self.websocket = websocket
-        self.logger = logger.bind(session_id=self.session_id)
-        self.credential: DefaultAzureCredential | None = None
-        self.client = self._initialize_client(backend)
-        self.logger.info("New session created")
-
-    async def __aenter__(self):
-        if self.credential is not None:
-            await self.credential.__aenter__()
-        await self.client.__aenter__()
-        return self
-
-    async def __aexit__(self, exc_type, exc_value, traceback):
-        await self.client.__aexit__(exc_type, exc_value, traceback)
-        if self.credential is not None:
-            await self.credential.__aexit__(exc_type, exc_value, traceback)
-        self.logger.info("Session closed")
-
-    def _initialize_client(self, backend: str | None):
-        self.logger.debug(f"Initializing RT client with backend: {backend}")
-
-        if backend == "azure" or backend is None:
-            self.logger.info(
-                "Using Azure OpenAI backend at %s with deployment %s",
-                os.getenv("AZURE_OPENAI_ENDPOINT"),
-                os.getenv("AZURE_OPENAI_DEPLOYMENT"),
-            )
-            self.credential = DefaultAzureCredential()
-
-            return RTClient(
-                url=os.getenv("AZURE_OPENAI_ENDPOINT"),
-                token_credential=self.credential,
-                azure_deployment=os.getenv("AZURE_OPENAI_DEPLOYMENT"),
-            )
-        return RTClient(
-            key_credential=AzureKeyCredential(os.getenv("OPENAI_API_KEY")),
-            model=os.getenv("OPENAI_MODEL"),
-        )
-
-    async def send(self, message: WSMessage):
-        await self.websocket.send_json(message)
-
-    async def send_binary(self, message: bytes):
-        await self.websocket.send_bytes(message)
-
-    async def initialize(self):
-        self.logger.debug("Configuring realtime session")
-        await self.client.configure(
-            modalities={"text", "audio"},
-            voice="coral",
-            input_audio_format="pcm16",
-            input_audio_transcription=InputAudioTranscription(model="whisper-1"),
-            turn_detection=ServerVAD(),
-        )
-
-        greeting: ControlMessage = {
-            "type": "control",
-            "action": "connected",
-            "greeting": "You are now connected to the FastAPI server",
-        }
-        await self.send(greeting)
-        self.logger.debug("Realtime session configured successfully")
-        asyncio.create_task(self.start_event_loop())
-
-    async def handle_binary_message(self, message: bytes):
-        try:
-            await self.client.send_audio(message)
-        except Exception as error:
-            self.logger.error(f"Failed to send audio data: {error}")
-            raise
-
-    async def handle_text_message(self, message: str):
-        try:
-            parsed: WSMessage = json.loads(message)
-            self.logger.debug(f"Received text message type: {parsed['type']}")
-
-            if parsed["type"] == "user_message":
-                await self.client.send_item(
-                    {
-                        "type": "message",
-                        "role": "user",
-                        "content": [{"type": "input_text", "text": parsed["text"]}],
-                    }
-                )
-                await self.client.generate_response()
-                self.logger.debug("User message processed successfully")
-        except Exception as error:
-            self.logger.error(f"Failed to process user message: {error}")
-            raise
-
-    async def handle_text_content(self, content):
-        try:
-            content_id = f"{content.item_id}-{content.content_index}"
-            async for text in content.text_chunks():
-                delta_message: TextDelta = {
-                    "id": content_id,
-                    "type": "text_delta",
-                    "delta": text,
-                }
-                await self.send(delta_message)
-
-            await self.send(
-                {"type": "control", "action": "text_done", "id": content_id}
-            )
-            self.logger.debug("Text content processed successfully")
-        except Exception as error:
-            self.logger.error(f"Error handling text content: {error}")
-            raise
-
-    async def handle_audio_content(self, content: RTAudioContent):
-        async def handle_audio_chunks():
-            async for chunk in content.audio_chunks():
-                await self.send_binary(chunk)
-
-        async def handle_audio_transcript():
-            content_id = f"{content.item_id}-{content.content_index}"
-            async for chunk in content.transcript_chunks():
-                await self.send(
-                    {"id": content_id, "type": "text_delta", "delta": chunk}
-                )
-            await self.send(
-                {"type": "control", "action": "text_done", "id": content_id}
-            )
-
-        try:
-            await asyncio.gather(handle_audio_chunks(), handle_audio_transcript())
-            self.logger.debug("Audio content processed successfully")
-        except Exception as error:
-            self.logger.error(f"Error handling audio content: {error}")
-            raise
-
-    async def handle_response(self, event: RTResponse):
-        try:
-            async for item in event:
-                if item.type == "message":
-                    async for content in item:
-                        if content.type == "text":
-                            await self.handle_text_content(content)
-                        elif content.type == "audio":
-                            await self.handle_audio_content(content)
-            self.logger.debug("Response handled successfully")
-        except Exception as error:
-            self.logger.error(f"Error handling response: {error}")
-            raise
-
-    async def handle_input_audio(self, event: RTInputAudioItem):
-        try:
-            await self.send({"type": "control", "action": "speech_started"})
-            await event
-
-            transcription: Transcription = {
-                "id": event.id,
-                "type": "transcription",
-                "text": event.transcript or "",
-            }
-            await self.send(transcription)
-            self.logger.debug(
-                f"Input audio processed successfully, transcription length: {len(transcription['text'])}"
-            )
-        except Exception as error:
-            self.logger.error(f"Error handling input audio: {error}")
-            raise
-
-    async def start_event_loop(self):
-        try:
-            self.logger.debug("Starting event loop")
-            async for event in self.client.events():
-                if event.type == "response":
-                    await self.handle_response(event)
-                elif event.type == "input_audio":
-                    await self.handle_input_audio(event)
-        except Exception as error:
-            self.logger.error(f"Error in event loop: {error}")
-            raise
-
-
 app = FastAPI()
-
-# Add CORS middleware
 app.add_middleware(
     CORSMiddleware,
     allow_origins=["*"],
@@ -393,20 +49,13 @@ app.add_middleware(
 @app.post("/phi3")
 async def phi3_endpoint(req: Phi3Request):
     global mem0
-
     llm = ModelFactory.create()
 
     session_id = req.session_id or "default"
     history = mem0.get(session_id, [])
 
-    final_prompt = req.prompt
-    context = ""
-
     context = document_store.search(req.prompt)
-
-    conversation = ""
-    if history:
-        conversation = "\n".join(f"User: {q}\nAssistant: {a}" for q, a in history)
+    conversation = "\n".join(f"User: {q}\nAssistant: {a}" for q, a in history) if history else ""
 
     if context:
         final_prompt = (
@@ -418,14 +67,15 @@ async def phi3_endpoint(req: Phi3Request):
         else:
             final_prompt += f"Question: {req.prompt}\nAnswer:"
     else:
-        if conversation:
-            final_prompt = f"{conversation}\nUser: {req.prompt}\nAssistant:"
-        else:
-            final_prompt = req.prompt
+        final_prompt = (
+            f"{conversation}\nUser: {req.prompt}\nAssistant:"
+            if conversation
+            else req.prompt
+        )
+
     logger.info(f"Final prompt for LLM: {final_prompt}")
     response = await llm.generate(final_prompt)
 
-    # Store the exchange for future context, keeping only the latest 10 turns
     history.append((req.prompt, response))
     mem0[session_id] = history[-10:]
 
@@ -440,22 +90,18 @@ async def websocket_endpoint(websocket: WebSocket):
     async with RTSession(websocket, os.getenv("BACKEND")) as session:
         try:
             await session.initialize()
-
             while websocket.client_state != WebSocketState.DISCONNECTED:
                 message = await websocket.receive()
                 if "bytes" in message:
                     await session.handle_binary_message(message["bytes"])
                 elif "text" in message:
                     await session.handle_text_message(message["text"])
-        except Exception as e:
-            logger.error(f"WebSocket error: {e}")
+        except Exception as exc:
+            logger.error(f"WebSocket error: {exc}")
         finally:
             if websocket.client_state == WebSocketState.CONNECTED:
                 await websocket.close()
             logger.info("WebSocket connection closed")
-
-
-from fastapi import UploadFile, File
 
 
 @app.post("/upload")
@@ -467,35 +113,29 @@ async def upload_file(file: UploadFile = File(...)):
 
     if ext == ".pdf":
         reader = PdfReader(io.BytesIO(contents))
-        text = "\n".join(
-            page.extract_text() for page in reader.pages if page.extract_text()
-        )
-    elif ext in {".txt"}:
+        text = "\n".join(page.extract_text() for page in reader.pages if page.extract_text())
+    elif ext == ".txt":
         text = contents.decode("utf-8", errors="ignore")
-    elif ext in {".md"}:
+    elif ext == ".md":
         md_text = contents.decode("utf-8", errors="ignore")
         html = markdown.markdown(md_text)
         text = BeautifulSoup(html, "html.parser").get_text()
-    elif ext in {".docx"}:
+    elif ext == ".docx":
         text = docx2txt.process(io.BytesIO(contents))
-    elif ext in {".doc"}:
+    elif ext == ".doc":
         with tempfile.NamedTemporaryFile(suffix=".doc") as tmp:
             tmp.write(contents)
             tmp.flush()
-            result = subprocess.run(
-                ["antiword", tmp.name], capture_output=True, text=True
-            )
+            result = subprocess.run(["antiword", tmp.name], capture_output=True, text=True)
             text = result.stdout
     elif ext in {".xls", ".xlsx"}:
         df = pd.read_excel(io.BytesIO(contents), header=None, dtype=str)
-        text = "\n".join(
-            " ".join(filter(None, map(str, row.dropna()))) for _, row in df.iterrows()
-        )
+        text = "\n".join(" ".join(filter(None, map(str, row.dropna()))) for _, row in df.iterrows())
     else:
         return {"error": "Unsupported file format."}
+
     logger.info(f"File {file.filename} processed, extracted text length: {len(text)}")
     document_store.update(text)
-
     return {"status": "Document uploaded and processed", "chunks": len(document_store.chunks)}
 
 

--- a/samples/middle-tier/python-fastapi/rt-middle-tier/main.py
+++ b/samples/middle-tier/python-fastapi/rt-middle-tier/main.py
@@ -31,18 +31,96 @@ import markdown
 import tempfile
 import subprocess
 import weaviate
-from weaviate.connect import ConnectionParams, ProtocolParams
 from weaviate.classes.data import DataObject
-from urllib.parse import urlparse
 from weaviate.classes.init import Auth
 from weaviate.classes.config import Configure, Property, DataType
+from abc import ABC, abstractmethod
+
 
 
 load_dotenv()
 
-document_chunks = []
-document_embeddings = []
 embedder = SentenceTransformer("all-MiniLM-L6-v2")
+
+class BaseLLMModel(ABC):
+    """Abstract base class for language models."""
+
+    @abstractmethod
+    async def generate(self, prompt: str) -> str:
+        pass
+
+
+class OllamaModel(BaseLLMModel):
+    def __init__(self, base_url: str, model: str) -> None:
+        self._client = Ollama(base_url=base_url, model=model)
+
+    async def generate(self, prompt: str) -> str:
+        return await self._client.apredict(prompt)
+
+
+class ModelFactory:
+    """Factory to create model instances."""
+
+    @staticmethod
+    def create(model_name: str | None = None) -> BaseLLMModel:
+        model_name = model_name or os.getenv("LLM_PROVIDER", "ollama")
+        if model_name == "ollama":
+            base_url = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
+            model = os.getenv("PHI3_MODEL", "phi3.5:3.8b")
+            return OllamaModel(base_url=base_url, model=model)
+        raise ValueError(f"Unknown model provider: {model_name}")
+
+
+class DocumentStore:
+    """Manage document chunks and semantic search."""
+
+    def __init__(self):
+        self.chunks: List[str] = []
+        self.embeddings = []
+        self.client = get_weaviate_client()
+
+    def update(self, text: str) -> None:
+        self.chunks = [text[i : i + 500] for i in range(0, len(text), 500)]
+        self.embeddings = embedder.encode(self.chunks)
+        if self.client is None:
+            logger.warning("Weaviate client is not initialized, skipping storage")
+            return
+        try:
+            try:
+                self.client.collections.delete("DocumentChunk")
+            except Exception:
+                logger.debug("No existing DocumentChunk class to delete")
+            self.client.collections.create(
+                name="DocumentChunk",
+                description="A collection of documents split into chunks for semantic search",
+                properties=[Property(name="text", data_type=DataType.TEXT)],
+                vectorizer_config=Configure.Vectorizer.none(),
+            )
+            collection = self.client.collections.get("DocumentChunk")
+            objects = [
+                DataObject(properties={"text": chunk}, vector=vector.tolist())
+                for chunk, vector in zip(self.chunks, self.embeddings)
+            ]
+            collection.data.insert_many(objects)
+            logger.info("Stored document chunks in Weaviate")
+        except Exception as exc:
+            logger.warning(f"Failed to store in Weaviate: {exc}")
+
+    def search(self, query: str) -> str:
+        if self.client is not None and self.client.collections.exists("DocumentChunk"):
+            collection = self.client.collections.get("DocumentChunk")
+            query_embedding = embedder.encode(query)
+            try:
+                results = collection.query.near_vector(query_embedding.tolist(), limit=3)
+                return "\n---\n".join(obj.properties["text"] for obj in results.objects)
+            except Exception as exc:
+                logger.warning(f"Weaviate query failed: {exc}")
+        if self.chunks and self.embeddings:
+            query_embedding = embedder.encode(query, convert_to_tensor=True)
+            top_results = util.semantic_search(query_embedding, self.embeddings, top_k=3)
+            return "\n---\n".join(self.chunks[match["corpus_id"]] for match in top_results[0])
+        return ""
+
 
 # Simple in-memory storage for conversation history.
 # Maps a session id to a list of (question, answer) tuples.
@@ -85,6 +163,8 @@ def get_weaviate_client():
             logger.warning(f"Could not connect to Weaviate: {e}")
     return weaviate_client
 
+
+document_store = DocumentStore()
 
 class TextDelta(TypedDict):
     id: str
@@ -312,11 +392,9 @@ app.add_middleware(
 
 @app.post("/phi3")
 async def phi3_endpoint(req: Phi3Request):
-    global document_chunks, document_embeddings, mem0
+    global mem0
 
-    base_url = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
-    model = os.getenv("PHI3_MODEL", "phi3.5:3.8b")
-    llm = Ollama(base_url=base_url, model=model)
+    llm = ModelFactory.create()
 
     session_id = req.session_id or "default"
     history = mem0.get(session_id, [])
@@ -324,25 +402,7 @@ async def phi3_endpoint(req: Phi3Request):
     final_prompt = req.prompt
     context = ""
 
-    client = get_weaviate_client()
-    if client is not None and client.collections.exists("DocumentChunk"):
-        logger.info("Using Weaviate for semantic search")
-        collection = client.collections.get("DocumentChunk")
-        query_embedding = embedder.encode(req.prompt)
-        try:
-            results = collection.query.near_vector(query_embedding.tolist(), limit=3)
-            context = "\n---\n".join(obj.properties["text"] for obj in results.objects)
-        except Exception as e:
-            logger.warning(f"Weaviate query failed: {e}")
-    elif len(document_chunks) > 0 and len(document_embeddings) > 0:
-        logger.info("Using in-memory document embeddings for semantic search")
-        query_embedding = embedder.encode(req.prompt, convert_to_tensor=True)
-        top_results = util.semantic_search(
-            query_embedding, document_embeddings, top_k=3
-        )
-        context = "\n---\n".join(
-            document_chunks[match["corpus_id"]] for match in top_results[0]
-        )
+    context = document_store.search(req.prompt)
 
     conversation = ""
     if history:
@@ -363,7 +423,7 @@ async def phi3_endpoint(req: Phi3Request):
         else:
             final_prompt = req.prompt
     logger.info(f"Final prompt for LLM: {final_prompt}")
-    response = await llm.apredict(final_prompt)
+    response = await llm.generate(final_prompt)
 
     # Store the exchange for future context, keeping only the latest 10 turns
     history.append((req.prompt, response))
@@ -401,7 +461,6 @@ from fastapi import UploadFile, File
 @app.post("/upload")
 async def upload_file(file: UploadFile = File(...)):
     logger.info(f"Received file upload: {file.filename}")
-    global document_chunks, document_embeddings
 
     contents = await file.read()
     ext = os.path.splitext(file.filename)[1].lower()
@@ -435,46 +494,9 @@ async def upload_file(file: UploadFile = File(...)):
     else:
         return {"error": "Unsupported file format."}
     logger.info(f"File {file.filename} processed, extracted text length: {len(text)}")
-    # Chunk and embed
-    document_chunks = [text[i : i + 500] for i in range(0, len(text), 500)]
-    embeddings = embedder.encode(document_chunks)
-    document_embeddings = embeddings
+    document_store.update(text)
 
-    client = get_weaviate_client()
-    if client is not None:
-        logger.info("Storing document chunks in Weaviate")
-        try:
-            try:
-                # Try to delete existing class if it exists
-                client.collections.delete("DocumentChunk")
-                logger.info("Deleted existing DocumentChunk class")
-            except:
-                logger.error("No existing DocumentChunk class to delete")
-            # if not client.collections.exists("DocumentChunk"):
-            logger.info("Creating Weaviate collection 'DocumentChunk'")
-            client.collections.create(
-                name="DocumentChunk",
-                 description="A collection of documents split into chunks for semantic search",
-                properties=[Property(name="text", data_type=DataType.TEXT)],
-                vectorizer_config=Configure.Vectorizer.none(),
-            )
-                # client.collections.create(
-                #     "DocumentChunk",
-                #     vectorizer="none",
-                #     properties=[{"name": "text", "dataType": "text"}],
-                # )
-            collection = client.collections.get("DocumentChunk")
-            objects = [
-                DataObject(properties={"text": chunk}, vector=vector.tolist())
-                for chunk, vector in zip(document_chunks, embeddings)
-            ]
-            collection.data.insert_many(objects)
-        except Exception as e:
-            logger.warning(f"Failed to store in Weaviate: {e}")
-    else:
-        logger.warning("Weaviate client is not initialized, skipping storage")
-
-    return {"status": "Document uploaded and processed", "chunks": len(document_chunks)}
+    return {"status": "Document uploaded and processed", "chunks": len(document_store.chunks)}
 
 
 if __name__ == "__main__":

--- a/samples/middle-tier/python-fastapi/rt-middle-tier/rt_session.py
+++ b/samples/middle-tier/python-fastapi/rt-middle-tier/rt_session.py
@@ -1,0 +1,217 @@
+import asyncio
+import json
+import os
+import uuid
+from typing import Literal, TypedDict, Union
+
+from azure.core.credentials import AzureKeyCredential
+from azure.identity.aio import DefaultAzureCredential
+from fastapi import WebSocket
+from fastapi.websockets import WebSocketState
+from loguru import logger
+from rtclient import (
+    InputAudioTranscription,
+    RTClient,
+    ServerVAD,
+    RTInputAudioItem,
+    RTResponse,
+    RTAudioContent,
+)
+
+
+class TextDelta(TypedDict):
+    id: str
+    type: Literal["text_delta"]
+    delta: str
+
+
+class Transcription(TypedDict):
+    id: str
+    type: Literal["transcription"]
+    text: str
+
+
+class UserMessage(TypedDict):
+    id: str
+    type: Literal["user_message"]
+    text: str
+
+
+class ControlMessage(TypedDict):
+    type: Literal["control"]
+    action: str
+    greeting: str | None = None
+    id: str | None = None
+
+
+WSMessage = Union[TextDelta, Transcription, UserMessage, ControlMessage]
+
+
+class RTSession:
+    """Manage a realtime WebSocket session."""
+
+    def __init__(self, websocket: WebSocket, backend: str | None) -> None:
+        self.session_id = str(uuid.uuid4())
+        self.websocket = websocket
+        self.logger = logger.bind(session_id=self.session_id)
+        self.credential: DefaultAzureCredential | None = None
+        self.client = self._initialize_client(backend)
+        self.logger.info("New session created")
+
+    async def __aenter__(self):
+        if self.credential is not None:
+            await self.credential.__aenter__()
+        await self.client.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type, exc_value, traceback):
+        await self.client.__aexit__(exc_type, exc_value, traceback)
+        if self.credential is not None:
+            await self.credential.__aexit__(exc_type, exc_value, traceback)
+        self.logger.info("Session closed")
+
+    def _initialize_client(self, backend: str | None) -> RTClient:
+        self.logger.debug("Initializing RT client with backend: %s", backend)
+        if backend == "azure" or backend is None:
+            self.logger.info(
+                "Using Azure OpenAI backend at %s with deployment %s",
+                os.getenv("AZURE_OPENAI_ENDPOINT"),
+                os.getenv("AZURE_OPENAI_DEPLOYMENT"),
+            )
+            self.credential = DefaultAzureCredential()
+            return RTClient(
+                url=os.getenv("AZURE_OPENAI_ENDPOINT"),
+                token_credential=self.credential,
+                azure_deployment=os.getenv("AZURE_OPENAI_DEPLOYMENT"),
+            )
+        return RTClient(
+            key_credential=AzureKeyCredential(os.getenv("OPENAI_API_KEY")),
+            model=os.getenv("OPENAI_MODEL"),
+        )
+
+    async def send(self, message: WSMessage) -> None:
+        await self.websocket.send_json(message)
+
+    async def send_binary(self, message: bytes) -> None:
+        await self.websocket.send_bytes(message)
+
+    async def initialize(self) -> None:
+        self.logger.debug("Configuring realtime session")
+        await self.client.configure(
+            modalities={"text", "audio"},
+            voice="coral",
+            input_audio_format="pcm16",
+            input_audio_transcription=InputAudioTranscription(model="whisper-1"),
+            turn_detection=ServerVAD(),
+        )
+        greeting: ControlMessage = {
+            "type": "control",
+            "action": "connected",
+            "greeting": "You are now connected to the FastAPI server",
+        }
+        await self.send(greeting)
+        self.logger.debug("Realtime session configured successfully")
+        asyncio.create_task(self.start_event_loop())
+
+    async def handle_binary_message(self, message: bytes) -> None:
+        try:
+            await self.client.send_audio(message)
+        except Exception as error:
+            self.logger.error("Failed to send audio data: %s", error)
+            raise
+
+    async def handle_text_message(self, message: str) -> None:
+        try:
+            parsed: WSMessage = json.loads(message)
+            self.logger.debug("Received text message type: %s", parsed["type"])
+            if parsed["type"] == "user_message":
+                await self.client.send_item(
+                    {
+                        "type": "message",
+                        "role": "user",
+                        "content": [{"type": "input_text", "text": parsed["text"]}],
+                    }
+                )
+                await self.client.generate_response()
+                self.logger.debug("User message processed successfully")
+        except Exception as error:
+            self.logger.error("Failed to process user message: %s", error)
+            raise
+
+    async def handle_text_content(self, content) -> None:
+        try:
+            content_id = f"{content.item_id}-{content.content_index}"
+            async for text in content.text_chunks():
+                delta_message: TextDelta = {
+                    "id": content_id,
+                    "type": "text_delta",
+                    "delta": text,
+                }
+                await self.send(delta_message)
+            await self.send({"type": "control", "action": "text_done", "id": content_id})
+            self.logger.debug("Text content processed successfully")
+        except Exception as error:
+            self.logger.error("Error handling text content: %s", error)
+            raise
+
+    async def handle_audio_content(self, content: RTAudioContent) -> None:
+        async def handle_audio_chunks():
+            async for chunk in content.audio_chunks():
+                await self.send_binary(chunk)
+
+        async def handle_audio_transcript():
+            content_id = f"{content.item_id}-{content.content_index}"
+            async for chunk in content.transcript_chunks():
+                await self.send({"id": content_id, "type": "text_delta", "delta": chunk})
+            await self.send({"type": "control", "action": "text_done", "id": content_id})
+
+        try:
+            await asyncio.gather(handle_audio_chunks(), handle_audio_transcript())
+            self.logger.debug("Audio content processed successfully")
+        except Exception as error:
+            self.logger.error("Error handling audio content: %s", error)
+            raise
+
+    async def handle_response(self, event: RTResponse) -> None:
+        try:
+            async for item in event:
+                if item.type == "message":
+                    async for content in item:
+                        if content.type == "text":
+                            await self.handle_text_content(content)
+                        elif content.type == "audio":
+                            await self.handle_audio_content(content)
+            self.logger.debug("Response handled successfully")
+        except Exception as error:
+            self.logger.error("Error handling response: %s", error)
+            raise
+
+    async def handle_input_audio(self, event: RTInputAudioItem) -> None:
+        try:
+            await self.send({"type": "control", "action": "speech_started"})
+            await event
+            transcription: Transcription = {
+                "id": event.id,
+                "type": "transcription",
+                "text": event.transcript or "",
+            }
+            await self.send(transcription)
+            self.logger.debug(
+                "Input audio processed successfully, transcription length: %s",
+                len(transcription["text"]),
+            )
+        except Exception as error:
+            self.logger.error("Error handling input audio: %s", error)
+            raise
+
+    async def start_event_loop(self) -> None:
+        try:
+            self.logger.debug("Starting event loop")
+            async for event in self.client.events():
+                if event.type == "response":
+                    await self.handle_response(event)
+                elif event.type == "input_audio":
+                    await self.handle_input_audio(event)
+        except Exception as error:
+            self.logger.error("Error in event loop: %s", error)
+            raise


### PR DESCRIPTION
## Summary
- refactor FastAPI example to support multiple LLM providers
- introduce `BaseLLMModel`, `OllamaModel`, and `ModelFactory`
- encapsulate document embedding logic with `DocumentStore`
- update `/phi3` and `/upload` handlers to use the new abstractions

## Testing
- `python -m py_compile samples/middle-tier/python-fastapi/rt-middle-tier/main.py`

------
https://chatgpt.com/codex/tasks/task_e_6858d68bc144832b81fbead04a65530a