### PR TITLE
Add Matrix theme

### DIFF
--- a/samples/middle-tier/generic-frontend/README.md
+++ b/samples/middle-tier/generic-frontend/README.md
@@ -10,7 +10,7 @@ A Next.js-based chat application demonstrating the usage of RTClient for real-ti
 - ☁️ Support for both OpenAI and Azure OpenAI
 - 🛠️ Configurable conversation settings
 - 🔧 Tool integration support (coming soon)
-- 🌙 Light and dark theme toggle
+- 🌙 Light, dark and Matrix theme toggle
 
 ## Prerequisites
 
@@ -42,7 +42,7 @@ yarn dev
 ```
 
 4. Open [http://localhost:3000](http://localhost:3000) in your browser.
-   Use the moon icon in the sidebar to switch between light and dark themes.
+   Use the moon icon in the sidebar to switch between light, dark, or Matrix themes.
 
 ## Usage
 

--- a/samples/middle-tier/generic-frontend/src/app/globals.css
+++ b/samples/middle-tier/generic-frontend/src/app/globals.css
@@ -98,6 +98,34 @@ body {
     --chart-4: 280 65% 60%;
     --chart-5: 340 75% 55%;
   }
+
+  .matrix {
+    /* Matrix-inspired black and green theme */
+    --background: 0 0% 0%;
+    --foreground: 120 100% 75%;
+    --card: 0 0% 0%;
+    --card-foreground: 120 100% 75%;
+    --popover: 0 0% 0%;
+    --popover-foreground: 120 100% 75%;
+    --primary: 120 69% 30%;
+    --primary-foreground: 0 0% 0%;
+    --secondary: 120 20% 12%;
+    --secondary-foreground: 120 100% 75%;
+    --muted: 120 20% 12%;
+    --muted-foreground: 120 30% 60%;
+    --accent: 120 69% 30%;
+    --accent-foreground: 0 0% 0%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 0 0% 98%;
+    --border: 120 100% 25%;
+    --input: 120 100% 25%;
+    --ring: 120 100% 50%;
+    --chart-1: 120 100% 50%;
+    --chart-2: 120 69% 40%;
+    --chart-3: 120 69% 60%;
+    --chart-4: 120 69% 30%;
+    --chart-5: 120 100% 70%;
+  }
 }
 
 @layer base {

--- a/samples/middle-tier/generic-frontend/src/components/theme-selector.tsx
+++ b/samples/middle-tier/generic-frontend/src/components/theme-selector.tsx
@@ -9,16 +9,17 @@ import {
   SelectItem,
 } from "@/components/ui/select";
 
-type Theme = "light" | "dark" | "dark-blue";
+type Theme = "light" | "dark" | "dark-blue" | "matrix";
 
 const themes: Record<Theme, { label: string; color: string }> = {
   light: { label: "Light", color: "#000000" },
   dark: { label: "Black", color: "#000000" },
   "dark-blue": { label: "Dark Blue", color: "#f08030" },
+  matrix: { label: "Matrix", color: "#39FF14" },
 };
 
 function applyTheme(theme: Theme) {
-  document.documentElement.classList.remove("dark", "dark-blue");
+  document.documentElement.classList.remove("dark", "dark-blue", "matrix");
   if (theme !== "light") {
     document.documentElement.classList.add(theme);
   }


### PR DESCRIPTION
## Summary
- add new "matrix" theme inspired by the movie's green on black aesthetic
- extend theme selector with the new option
- document the theme in the README

## Testing
- `npm run lint` in `samples/middle-tier/generic-frontend`

------
https://chatgpt.com/codex/tasks/task_e_685ee18dd8bc832bafa1d2743880dfc1